### PR TITLE
.gitignore rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@ dependency-reduced-pom*.xml
 !*.properties.example
 
 # Environment files
-.env
-.env.local
+.env*
 !.env.example
 
 # Secrets / keys (local)

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Maven build output
 target/
+dependency-reduced-pom*.xml
 
 # Config files
 *.properties

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,20 @@
 # Maven build output
 target/
-dependency-reduced-pom*.xml
+
+# Config files
+*.properties
+!*.properties.example
+
+# Environment files
+.env
+.env.local
+!.env.example
+
+# Secrets / keys (local)
+*.key
+*.pem
+*.p12
+*.jks
 
 # IntelliJ IDEA settings (auto-generated from pom.xml)
 .idea/
@@ -28,6 +42,3 @@ Thumbs.db
 
 # Log files
 *.log
-
-# Configuration files
-*.properties


### PR DESCRIPTION
Reworked .gitignore
It now includes:
*.properties
.env*

and excludes the example version of these.